### PR TITLE
Fix for multiple argument parsing

### DIFF
--- a/src/clean/code/chapter14/solution/Args.java
+++ b/src/clean/code/chapter14/solution/Args.java
@@ -49,7 +49,7 @@ public class Args {
   }
 
   private void parseArgumentStrings(List<String> argsList) throws ArgsException {
-    if (argsList.size() > 0) {
+    for (currentArgument = argsList.listIterator(); currentArgument.hasNext();) {
       currentArgument = argsList.listIterator();
       String argString = currentArgument.next();
       if (argString.startsWith("-")) {


### PR DESCRIPTION
I checked out the Args class and found a small bug that prevented valid behaviour when we want to pass multiple args to the class